### PR TITLE
Change logger info to errors where appropriate

### DIFF
--- a/.act.yaml
+++ b/.act.yaml
@@ -1,11 +1,11 @@
 revision: 20220824
 image_name: arcaflow-plugin-template-python
-image_tag: '0.1.0'
-project_filepath: /github/workspace
+image_tag: 'test'
+project_filepath: /home/jdownie/git/arcaflow-plugin/arcaflow-plugin-template-python
 quay_exp: 'never'
 registries:
   - url: quay.io
     username_envvar: "QUAY_USERNAME"
     password_envvar: "QUAY_PASSWORD"
     namespace_envvar: "QUAY_NAMESPACE"
-    quay_custom_namespace_envvar: "QUAY_CUSTOM_NAMESPACE"
+

--- a/.act.yaml
+++ b/.act.yaml
@@ -1,11 +1,11 @@
 revision: 20220824
 image_name: arcaflow-plugin-template-python
-image_tag: 'test'
-project_filepath: /home/jdownie/git/arcaflow-plugin/arcaflow-plugin-template-python
+image_tag: '0.1.0'
+project_filepath: /github/workspace
 quay_exp: 'never'
 registries:
   - url: quay.io
     username_envvar: "QUAY_USERNAME"
     password_envvar: "QUAY_PASSWORD"
     namespace_envvar: "QUAY_NAMESPACE"
-
+    quay_custom_namespace_envvar: "QUAY_CUSTOM_NAMESPACE"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49
+          version: v1.52.2
 
   test:
     runs-on: ubuntu-latest

--- a/internal/act/act.go
+++ b/internal/act/act.go
@@ -2,6 +2,7 @@ package act
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	log2 "log"
 	"os"
@@ -70,7 +71,10 @@ func AllTrue(checks []bool) bool {
 func CliACT(build bool, push bool, logger log.Logger, cec_choice string) error {
 	conf, err := dto.Unmarshal(push, logger)
 	if err != nil {
-		return fmt.Errorf("error in act configuration file (%w)", err)
+		return fmt.Errorf("error found in configuration: (%w)", err)
+	}
+	if push && len(conf.Registries) == 0 {
+		return errors.New("no registries passed configuration with the push argument")
 	}
 	cleanpath := filepath.Clean(conf.Project_Filepath)
 	abspath, err := filepath.Abs(cleanpath)

--- a/internal/act/act.go
+++ b/internal/act/act.go
@@ -68,7 +68,7 @@ func AllTrue(checks []bool) bool {
 }
 
 func CliACT(build bool, push bool, logger log.Logger, cec_choice string) error {
-	conf, err := dto.Unmarshal(logger)
+	conf, err := dto.Unmarshal(push, logger)
 	if err != nil {
 		return fmt.Errorf("error in act configuration file (%w)", err)
 	}

--- a/internal/dto/act.go
+++ b/internal/dto/act.go
@@ -22,10 +22,10 @@ func Unmarshal(push bool, logger log.Logger) (ACT, error) {
 	var registries Registries
 	if push {
 		filteredRegistries, err := UnmarshalRegistries(logger)
-		registries = filteredRegistries
 		if err != nil {
 			return ACT{}, err
 		}
+		registries = filteredRegistries
 	}
 	conf := ACT{
 		Revision:         viper.GetString("revision"),

--- a/internal/dto/act.go
+++ b/internal/dto/act.go
@@ -18,10 +18,14 @@ type ACT struct {
 	Registries       []Registry
 }
 
-func Unmarshal(logger log.Logger) (ACT, error) {
-	filteredRegistries, err := UnmarshalRegistries(logger)
-	if err != nil {
-		return ACT{}, err
+func Unmarshal(push bool, logger log.Logger) (ACT, error) {
+	var registries Registries
+	if push {
+		filteredRegistries, err := UnmarshalRegistries(logger)
+		registries = filteredRegistries
+		if err != nil {
+			return ACT{}, err
+		}
 	}
 	conf := ACT{
 		Revision:         viper.GetString("revision"),
@@ -30,7 +34,7 @@ func Unmarshal(logger log.Logger) (ACT, error) {
 		Image_Tag:        viper.GetString("image_tag"),
 		Quay_Img_Exp:     viper.GetString("quay_img_exp"),
 		Build_Timeout:    viper.GetUint32("build_timeout"),
-		Registries:       filteredRegistries}
+		Registries:       registries}
 	if err := defaults.Set(&conf); err != nil {
 		return ACT{}, fmt.Errorf("error setting defaults (%w)", err)
 	}

--- a/internal/dto/env.go
+++ b/internal/dto/env.go
@@ -1,24 +1,17 @@
 package dto
 
 import (
-	"fmt"
-	"go.arcalot.io/log"
 	"os"
+
+	"go.arcalot.io/log"
 )
 
-func LookupEnvVar(key string, logger log.Logger) Verbose {
+func LookupEnvVar(registries string, key string, logger log.Logger) string {
 	val, ok := os.LookupEnv(key)
-	var msg string
 	if !ok {
-		msg = fmt.Sprintf("%s not set", key)
+		logger.Errorf("%s not set for %s", key, registries)
 	} else if len(val) == 0 {
-		msg = fmt.Sprintf("%s is empty", key)
+		logger.Errorf("%s empty for %s", key, registries)
 	}
-	logger.Infof(msg)
-	return Verbose{Return_value: val, Msg: msg}
-}
-
-type Verbose struct {
-	Msg          string
-	Return_value string
+	return val
 }

--- a/internal/dto/env.go
+++ b/internal/dto/env.go
@@ -7,8 +7,9 @@ import (
 	"go.arcalot.io/log"
 )
 
-// LookupEnvVar returns an error if an environment variable is not set or empty.
-// The error includes the registry url to destinguish which registry encountered the error.
+// LookupEnvVar returns the value of an enviornment variable.
+// lookupEnvVar will return an error if the enviornment variable is not set or empty.
+// The error includes the registry url to destinguish which registry encountered the error if found.
 func LookupEnvVar(registry_url string, key string, logger log.Logger) (string, error) {
 	val, ok := os.LookupEnv(key)
 	if !ok {

--- a/internal/dto/env.go
+++ b/internal/dto/env.go
@@ -7,6 +7,7 @@ import (
 	"go.arcalot.io/log"
 )
 
+// LookupEnvVar verifies that an environment variable is set and not empty
 func LookupEnvVar(registry_url string, key string, logger log.Logger) (string, error) {
 	val, ok := os.LookupEnv(key)
 	if !ok {

--- a/internal/dto/env.go
+++ b/internal/dto/env.go
@@ -1,17 +1,20 @@
 package dto
 
 import (
+	"fmt"
 	"os"
 
 	"go.arcalot.io/log"
 )
 
-func LookupEnvVar(registries string, key string, logger log.Logger) string {
+func LookupEnvVar(registries string, key string, logger log.Logger) (string, error) {
 	val, ok := os.LookupEnv(key)
 	if !ok {
-		logger.Errorf("%s not set for %s", key, registries)
+		err := fmt.Errorf("%s environment variable not set to push to %s", key, registries)
+		return "", err
 	} else if len(val) == 0 {
-		logger.Errorf("%s empty for %s", key, registries)
+		err := fmt.Errorf("%s environment variable empty to push to %s", key, registries)
+		return "", err
 	}
-	return val
+	return val, nil
 }

--- a/internal/dto/env.go
+++ b/internal/dto/env.go
@@ -7,7 +7,8 @@ import (
 	"go.arcalot.io/log"
 )
 
-// LookupEnvVar verifies that an environment variable is set and not empty
+// LookupEnvVar returns an error if an environment variable is not set or empty.
+// The error includes the registry url to destinguish which registry encountered the error.
 func LookupEnvVar(registry_url string, key string, logger log.Logger) (string, error) {
 	val, ok := os.LookupEnv(key)
 	if !ok {

--- a/internal/dto/env.go
+++ b/internal/dto/env.go
@@ -7,13 +7,13 @@ import (
 	"go.arcalot.io/log"
 )
 
-func LookupEnvVar(registries string, key string, logger log.Logger) (string, error) {
+func LookupEnvVar(registry_url string, key string, logger log.Logger) (string, error) {
 	val, ok := os.LookupEnv(key)
 	if !ok {
-		err := fmt.Errorf("%s environment variable not set to push to %s", key, registries)
+		err := fmt.Errorf("%s environment variable not set to push to %s", key, registry_url)
 		return "", err
 	} else if len(val) == 0 {
-		err := fmt.Errorf("%s environment variable empty to push to %s", key, registries)
+		err := fmt.Errorf("%s environment variable empty to push to %s", key, registry_url)
 		return "", err
 	}
 	return val, nil

--- a/internal/dto/env_test.go
+++ b/internal/dto/env_test.go
@@ -17,14 +17,20 @@ func TestLookupEnvVar(t *testing.T) {
 	envvar_key := "i_hope_this_isnt_used"
 	envvar_val := ""
 
-	v := dto.LookupEnvVar(registries, envvar_key, logger)
-	assert.Equals(t, v, fmt.Sprintf("%s not set", envvar_key))
-
-	err := os.Setenv(envvar_key, envvar_val)
+	v, err := dto.LookupEnvVar(registries, envvar_key, logger)
 	if err != nil {
 		log.Fatal(err)
 	}
-	v = dto.LookupEnvVar(registries, envvar_key, logger)
+	assert.Equals(t, v, fmt.Sprintf("%s not set", envvar_key))
+
+	err = os.Setenv(envvar_key, envvar_val)
+	if err != nil {
+		log.Fatal(err)
+	}
+	v, err = dto.LookupEnvVar(registries, envvar_key, logger)
+	if err != nil {
+		log.Fatal(err)
+	}
 	assert.Equals(t, v, fmt.Sprintf("%s is empty", envvar_key))
 
 	envvar_val = "robot"
@@ -32,7 +38,10 @@ func TestLookupEnvVar(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	v = dto.LookupEnvVar(registries, envvar_key, logger)
+	v, err = dto.LookupEnvVar(registries, envvar_key, logger)
+	if err != nil {
+		log.Fatal(err)
+	}
 	assert.Equals(t, v, "")
 
 	err = os.Unsetenv(envvar_key)

--- a/internal/dto/env_test.go
+++ b/internal/dto/env_test.go
@@ -12,30 +12,28 @@ import (
 )
 
 func TestLookupEnvVar(t *testing.T) {
+	registries := "test"
 	logger := arcalog.NewLogger(arcalog.LevelInfo, arcalog.NewNOOPLogger())
 	envvar_key := "i_hope_this_isnt_used"
 	envvar_val := ""
 
-	v := dto.LookupEnvVar(envvar_key, logger)
-	assert.Equals(t, v.Msg, fmt.Sprintf("%s not set", envvar_key))
-	assert.Equals(t, v.Return_value, "")
+	v := dto.LookupEnvVar(registries, envvar_key, logger)
+	assert.Equals(t, v, fmt.Sprintf("%s not set", envvar_key))
 
 	err := os.Setenv(envvar_key, envvar_val)
 	if err != nil {
 		log.Fatal(err)
 	}
-	v = dto.LookupEnvVar(envvar_key, logger)
-	assert.Equals(t, v.Msg, fmt.Sprintf("%s is empty", envvar_key))
-	assert.Equals(t, v.Return_value, "")
+	v = dto.LookupEnvVar(registries, envvar_key, logger)
+	assert.Equals(t, v, fmt.Sprintf("%s is empty", envvar_key))
 
 	envvar_val = "robot"
 	err = os.Setenv(envvar_key, envvar_val)
 	if err != nil {
 		log.Fatal(err)
 	}
-	v = dto.LookupEnvVar(envvar_key, logger)
-	assert.Equals(t, v.Msg, "")
-	assert.Equals(t, v.Return_value, envvar_val)
+	v = dto.LookupEnvVar(registries, envvar_key, logger)
+	assert.Equals(t, v, "")
 
 	err = os.Unsetenv(envvar_key)
 	if err != nil {

--- a/internal/dto/env_test.go
+++ b/internal/dto/env_test.go
@@ -1,7 +1,6 @@
 package dto_test
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -14,24 +13,21 @@ import (
 func TestLookupEnvVar(t *testing.T) {
 	registries := "test"
 	logger := arcalog.NewLogger(arcalog.LevelInfo, arcalog.NewNOOPLogger())
-	envvar_key := "i_hope_this_isnt_used"
-	envvar_val := ""
+	envvar_key := "foo"
+	envvar_val := "bar"
 
-	v, err := dto.LookupEnvVar(registries, envvar_key, logger)
-	if err != nil {
-		log.Fatal(err)
-	}
-	assert.Equals(t, v, fmt.Sprintf("%s not set", envvar_key))
+	_, err := dto.LookupEnvVar(registries, envvar_key, logger)
+	assert.Error(t, err)
 
 	err = os.Setenv(envvar_key, envvar_val)
 	if err != nil {
 		log.Fatal(err)
 	}
-	v, err = dto.LookupEnvVar(registries, envvar_key, logger)
+	v, err := dto.LookupEnvVar(registries, envvar_key, logger)
 	if err != nil {
 		log.Fatal(err)
 	}
-	assert.Equals(t, v, fmt.Sprintf("%s is empty", envvar_key))
+	assert.Equals(t, v, envvar_val)
 
 	envvar_val = "robot"
 	err = os.Setenv(envvar_key, envvar_val)
@@ -42,7 +38,7 @@ func TestLookupEnvVar(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	assert.Equals(t, v, "")
+	assert.Equals(t, v, "robot")
 
 	err = os.Unsetenv(envvar_key)
 	if err != nil {

--- a/internal/dto/registry.go
+++ b/internal/dto/registry.go
@@ -64,10 +64,14 @@ func (registries Registries) Parse(logger log.Logger) (Registries, error) {
 		password_envvar := registries[i].Password_Envvar
 		namespace_envvar := registries[i].Namespace_Envvar
 		quay_custom_namespace_envvar := registries[i].Quay_Custom_Namespace_Envvar
-		username := LookupEnvVar(username_envvar, logger).Return_value
-		password := LookupEnvVar(password_envvar, logger).Return_value
-		namespace := LookupEnvVar(namespace_envvar, logger).Return_value
-		quay_custom_namespace := LookupEnvVar(quay_custom_namespace_envvar, logger).Return_value
+		if quay_custom_namespace_envvar != "" && registries[i].Url == "quay.io" {
+			logger.Infof("QUAY_CUSTOM_NAMESPACE environment variable detected,"+
+				"using value in place of QUAY_NAMESPACE for %s", registries[i].Url)
+			namespace_envvar = quay_custom_namespace_envvar
+		}
+		username := LookupEnvVar(registries[i].Url, username_envvar, logger)
+		password := LookupEnvVar(registries[i].Url, password_envvar, logger)
+		namespace := LookupEnvVar(registries[i].Url, namespace_envvar, logger)
 		if !registries[i].ValidCredentials(username) {
 			logger.Infof("Missing credentials for %s\n", registries[i].Url)
 			misconfigured_registries[strconv.FormatInt(int64(i), 10)] = PlaceHolder
@@ -75,15 +79,13 @@ func (registries Registries) Parse(logger log.Logger) (Registries, error) {
 		}
 		registries[i].Username = username
 		registries[i].Password = password
-		if quay_custom_namespace != "" && registries[i].Url == "quay.io" {
-			registries[i].Namespace = quay_custom_namespace
-		} else {
-			inferred_namespace, err := InferNamespace(namespace, username)
-			if err != nil {
-				return nil, err
-			}
-			registries[i].Namespace = inferred_namespace
+
+		inferred_namespace, err := InferNamespace(namespace, username)
+		if err != nil {
+			return nil, err
 		}
+		registries[i].Namespace = inferred_namespace
+
 	}
 	filteredRegistries := FilterByIndex(registries, misconfigured_registries)
 	return filteredRegistries, nil

--- a/internal/dto/registry_test.go
+++ b/internal/dto/registry_test.go
@@ -69,10 +69,10 @@ func TestRegistries_Parse(t *testing.T) {
 	envvars := map[string]string{
 		"reg1_username":  "reg1_username",
 		"reg1_password":  "reg1_password",
-		"reg1_namespace": "",
+		"reg1_namespace": "reg1_namespace",
 		"reg2_username":  "reg2_username+robot",
 		"reg2_password":  "reg2_password",
-		"reg2_namespace": "",
+		"reg2_namespace": "reg2_namespace",
 	}
 
 	reg2_namespace := envvars["reg2_namespace"]
@@ -108,13 +108,13 @@ func TestRegistries_Parse(t *testing.T) {
 	assert.Equals(t, v, rs2[0].Username)
 	v = envvars["reg1_password"]
 	assert.Equals(t, v, rs2[0].Password)
-	assert.Equals(t, "reg1_username", rs2[0].Namespace)
+	assert.Equals(t, "reg1_namespace", rs2[0].Namespace)
 
 	v = envvars["reg2_username"]
 	assert.Equals(t, v, rs2[1].Username)
 	v = envvars["reg2_password"]
 	assert.Equals(t, v, rs2[1].Password)
-	assert.Equals(t, "reg2_username", rs2[1].Namespace)
+	assert.Equals(t, "reg2_namespace", rs2[1].Namespace)
 
 	for envvar_key := range envvars {
 		err := os.Unsetenv(envvar_key)

--- a/internal/requirements/basic.go
+++ b/internal/requirements/basic.go
@@ -4,21 +4,18 @@ import "go.arcalot.io/log"
 
 func BasicRequirements(filenames []string, logger log.Logger) (bool, error) {
 	meets_reqs := true
-	output := ""
 
 	if present, err := HasFilename(filenames, "README.md"); err != nil {
 		return false, err
 	} else if !present {
-		output = "Missing README.md\n"
-		logger.Infof(output)
+		logger.Errorf("Missing required file README.md")
 		meets_reqs = false
 	}
 
 	if present, err := HasFilename(filenames, "Dockerfile"); err != nil {
 		return false, err
 	} else if !present {
-		output = "Missing Dockerfile\n"
-		logger.Infof(output)
+		logger.Errorf("Missing required file Dockerfile")
 		meets_reqs = false
 	}
 
@@ -26,10 +23,8 @@ func BasicRequirements(filenames []string, logger log.Logger) (bool, error) {
 		return false, err
 	} else if !present {
 		// match case-insensitive 'test'?
-		output = "Missing a test file\n"
-		logger.Infof(output)
+		logger.Errorf("Missing required test file")
 		meets_reqs = false
 	}
-
 	return meets_reqs, nil
 }


### PR DESCRIPTION
## Changes introduced with this PR

This is to address #53 by doing the following:

- Change logger info to errors where appropriate
- Only parse registries when the push argument is provided to ACT
- Update the LookupEnv function to return errors that can be passed upstream
- Display more helpful error messages when one occurs.
- Stop the build and attempt to push when credentials are incorrectly set or missing in the environment variables
- Return an error message to the main Cobra command build if all registries do not pass credentials when the push argument is declared.

These changes should make messages much more clear where the error is when running. It additionally will reduce the build time wait if there are any errors up front. This will prevent ACT of going through the motions of the build just to fail when attempting to push.


---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).