### PR TITLE
Archetype and Multi-Arch workflow build

### DIFF
--- a/.act.yaml
+++ b/.act.yaml
@@ -3,7 +3,7 @@ image_name: arcaflow-plugin-template-python
 image_tag: '0.1.0'
 project_filepath: /github/workspace
 quay_exp: 'never'
-architypes: []
+architypes: ''
 registries:
   - url: quay.io
     username_envvar: "QUAY_USERNAME"

--- a/.act.yaml
+++ b/.act.yaml
@@ -3,6 +3,7 @@ image_name: arcaflow-plugin-template-python
 image_tag: '0.1.0'
 project_filepath: /github/workspace
 quay_exp: 'never'
+architypes: []
 registries:
   - url: quay.io
     username_envvar: "QUAY_USERNAME"

--- a/.act.yaml
+++ b/.act.yaml
@@ -3,7 +3,8 @@ image_name: arcaflow-plugin-template-python
 image_tag: '0.1.0'
 project_filepath: /github/workspace
 quay_exp: 'never'
-architypes: ''
+archetype: ''
+req_check_only: false
 registries:
   - url: quay.io
     username_envvar: "QUAY_USERNAME"

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/setup-qemu-action@v2
         
       - name: arcaflow-container-toolkit-action
-        uses: jdowni000/arcaflow-container-toolkit-action@v0.0.1
+        uses: arcalot/arcaflow-container-toolkit-action@v2.0.0
         with:
           image_name: ${{ inputs.image_name }}
           image_tag: ${{ inputs.image_tag }}

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -91,6 +91,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/ppc64le
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ inputs.image_tag }}"

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -75,11 +75,11 @@ jobs:
           req_check_only: ${{ inputs.multi_arch }}
 
       - name: Set up Docker Buildx
-        if: ${{ inputs.multi-arch }}
+        if: ${{ inputs.multi_arch }}
         uses: docker/setup-buildx-action@v2
 
       - name: Login to Quay
-        if: ${{ inputs.multi-arch }}
+        if: ${{ inputs.multi_arch }}
         uses: docker/login-action@v2
         with:
           registry: quay.io
@@ -87,7 +87,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build and push
-        if: ${{ inputs.multi-arch }}
+        if: ${{ inputs.multi_arch }}
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/setup-qemu-action@v2
         
       - name: arcaflow-container-toolkit-action
-        uses: arcalot/arcaflow-container-toolkit-action@v2.0.0
+        uses: arcalot/arcaflow-container-toolkit-action@v1.3.0
         with:
           image_name: ${{ inputs.image_name }}
           image_tag: ${{ inputs.image_tag }}

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -93,4 +93,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ inputs.image_tag }}
+          tags: "${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ inputs.image_tag }}"

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -91,6 +91,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
           push: true
           tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ inputs.image_tag }}"

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -50,6 +50,9 @@ jobs:
       
       - name: Checkout this project
         uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
         
       - name: arcaflow-container-toolkit-action
         uses: jdowni000/arcaflow-container-toolkit-action@v0.0.1

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -93,4 +93,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: "${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ inputs.image_tag }}"
+          tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ inputs.image_tag }}"

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -19,7 +19,10 @@ on:
         type: string
       github_namespace:
         required: false
-        type: string    
+        type: string
+      architypes:
+        required: false
+        type: string   
     secrets:
       QUAY_NAMESPACE:
         required: false
@@ -49,7 +52,7 @@ jobs:
         uses: actions/checkout@v3
         
       - name: arcaflow-container-toolkit-action
-        uses: arcalot/arcaflow-container-toolkit-action@v1.2.1
+        uses: jdowni000/arcaflow-container-toolkit-action@v0.0.1
         with:
           image_name: ${{ inputs.image_name }}
           image_tag: ${{ inputs.image_tag }}
@@ -62,3 +65,4 @@ jobs:
           quay_custom_namespace: ${{ inputs.quay_custom_namespace }}
           quay_img_exp: ${{ inputs.quay_img_exp }}
           build_timeout: ${{ inputs.build_timeout }}
+          architypes: ${{ inputs.architypes }}

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -74,11 +74,11 @@ jobs:
           archetype: ${{ inputs.archetype }}
           req_check_only: ${{ inputs.multi_arch }}
 
-      - name: Set up Docker Buildx
+      - name: Set up Docker Buildx for Multi-Arch
         if: ${{ inputs.multi_arch }}
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to Quay
+      - name: Login to Quay for Multi-Arch
         if: ${{ inputs.multi_arch }}
         uses: docker/login-action@v2
         with:
@@ -86,7 +86,7 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Build and push
+      - name: Build and push for Multi-Arch
         if: ${{ inputs.multi_arch }}
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -20,9 +20,12 @@ on:
       github_namespace:
         required: false
         type: string
-      architypes:
+      archetype:
         required: false
-        type: string   
+        type: string
+      multi_arch:
+        required: false
+        type: boolean   
     secrets:
       QUAY_NAMESPACE:
         required: false
@@ -68,4 +71,26 @@ jobs:
           quay_custom_namespace: ${{ inputs.quay_custom_namespace }}
           quay_img_exp: ${{ inputs.quay_img_exp }}
           build_timeout: ${{ inputs.build_timeout }}
-          architypes: ${{ inputs.architypes }}
+          archetype: ${{ inputs.archetype }}
+          req_check_only: ${{ inputs.multi_arch }}
+
+      - name: Set up Docker Buildx
+        if: ${{ inputs.multi-arch }}
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Quay
+        if: ${{ inputs.multi-arch }}
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push
+        if: ${{ inputs.multi-arch }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ inputs.image_tag }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,9 +28,9 @@ archives:
 dockers:
   - dockerfile: Dockerfile.goreleaser
     image_templates:
-      - ghcr.io/jdowni000/arcaflow-container-toolkit:{{ .Tag }}
-      - ghcr.io/jdowni000/arcaflow-container-toolkit:{{ .Major }}
-      - ghcr.io/jdowni000/arcaflow-container-toolkit:latest
+      - ghcr.io/arcalot/arcaflow-container-toolkit:{{ .Tag }}
+      - ghcr.io/arcalot/arcaflow-container-toolkit:{{ .Major }}
+      - ghcr.io/arcalot/arcaflow-container-toolkit:latest
     extra_files:
       - .act.yaml
 checksum:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,9 +28,9 @@ archives:
 dockers:
   - dockerfile: Dockerfile.goreleaser
     image_templates:
-      - ghcr.io/arcalot/arcaflow-container-toolkit:{{ .Tag }}
-      - ghcr.io/arcalot/arcaflow-container-toolkit:{{ .Major }}
-      - ghcr.io/arcalot/arcaflow-container-toolkit:latest
+      - ghcr.io/jdowni000/arcaflow-container-toolkit:{{ .Tag }}
+      - ghcr.io/jdowni000/arcaflow-container-toolkit:{{ .Major }}
+      - ghcr.io/jdowni000/arcaflow-container-toolkit:latest
     extra_files:
       - .act.yaml
 checksum:

--- a/README.md
+++ b/README.md
@@ -63,13 +63,12 @@ registries:
   `QUAY_CUSTOM_NAMESPACE` Quay Namespace to push image that is not QUAY_NAMESPACE - Default: ""  
   `QUAY_IMG_EXP` Image label to automatically expire in Quay - Default: "never"  
   `BUILD_TIMEOUT` Length of time before a build will fail in seconds - Default: 600  
-  `ARCHITYPES` Architecure(s) of image to build with - Default: ""
+  `ARCHETYPE` Request architecture (platform) of image to build with - Default: ""
 
 #### Additional Information
 
 * `QUAY_IMG_EXP` more documentation and time formats can be found [here](https://docs.projectquay.io/use_quay.html#:~:text=Setting%20tag%20expiration%20from%20a%20Dockerfile)
-* `QUAY_CUSTOM_NAMESPACE` if set, will use in place of `QUAY_NAMESPACE`. More info [Arcaflow Container Toolkit and Reusable Workflows](#arcaflow-container-toolkit-and-reusable-workflows)
-* `ARCHITYPES` supports multiple architecture types. Pass multiple arguments as a single string with a space between. Architypes information can be found [here](https://docs.docker.com/build/building/multi-platform/)  
+* `QUAY_CUSTOM_NAMESPACE` if set, will use in place of `QUAY_NAMESPACE`. More info [Arcaflow Container Toolkit and Reusable Workflows](#arcaflow-container-toolkit-and-reusable-workflows) 
 
 ## Build Arcaflow Container Toolkit as an Executable Locally
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ registries:
   `QUAY_IMG_EXP` Image label to automatically expire in Quay - Default: "never"  
   `BUILD_TIMEOUT` Length of time before a build will fail in seconds - Default: 600  
   `ARCHETYPE` Request architecture (platform) of image to build with - Default: ""
+  `REQ_CHECK_ONLY` Disables build and push but still checks requirements - Default: False
 
 #### Additional Information
 
@@ -135,7 +136,9 @@ jobs:
     uses: arcalot/arcaflow-container-toolkit/.github/workflows/reusable_workflow.yaml@main
     with:
       image_name: ${{ github.event.repository.name }}
-      image_tag: 'latest'     
+      image_tag: 'latest'
+      archetype: 'arm64' # Optional input for demonstration purposes
+      multi_arch: True # Optional input for demonstration purposes     
     secrets: 
       QUAY_NAMESPACE: ${{ secrets.QUAY_NAMESPACE }}
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
@@ -148,6 +151,8 @@ jobs:
 * This workflow will automatically configure `IMAGE_TAG` to version if a release is detected.
 * This workflow will automatically configure `IMAGE_TAG` to the format `branch_commit-hash[0:7]` if a development branch is detected.
 * This workflow will automatically configure `QUAY_IMG_EXP` to 90 days if a development branch is detected.
+* Setting the `archetype` input will configure the `ARCHETYPE` env variable.
+* Setting the `multi_arch` input will configure the `REQ_CHECK_ONLY` env variable to True, thus allowing docker buildx to handle the build and push functionality in the [workflow](arcalot/arcaflow-containter-toolkit/.github/workflows/reusable_workflow.yaml) for multi-arch builds.
 
 ## Arcaflow Container Toolkit as an Action
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ registries:
   `QUAY_CUSTOM_NAMESPACE` Quay Namespace to push image that is not QUAY_NAMESPACE - Default: ""  
   `QUAY_IMG_EXP` Image label to automatically expire in Quay - Default: "never"  
   `BUILD_TIMEOUT` Length of time before a build will fail in seconds - Default: 600  
-  `ARCHETYPE` Request architecture (platform) of image to build with - Default: ""
+  `ARCHETYPE` Request architecture (platform) of image to build with - Default: ""  
   `REQ_CHECK_ONLY` Disables build and push but still checks requirements - Default: False
 
 #### Additional Information

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ example `.act.yaml`
 revision: 20220824
 image_name: "<IMAGE_NAME>"
 image_tag: "<IMAGE_TAG>"
+quay_exp: 'never'
+archetype: ''
+req_check_only: false
 project_filepath: "<path/to/plugin/project/>"
 registries:
   - url: quay.io

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ jobs:
 * This workflow will automatically configure `IMAGE_TAG` to the format `branch_commit-hash[0:7]` if a development branch is detected.
 * This workflow will automatically configure `QUAY_IMG_EXP` to 90 days if a development branch is detected.
 * Setting the `archetype` input will configure the `ARCHETYPE` env variable.  
-* Setting the `multi_arch` input will configure the `REQ_CHECK_ONLY` env variable to True, thus allowing docker buildx to handle the build and push functionality in the [workflow](.github/workflows/reusable_workflow.yaml) for multi-arch builds.
+* Setting the `multi_arch` input will configure the `REQ_CHECK_ONLY` env variable to True, thus allowing docker buildx to handle the build and push functionality in the [workflow](.github/workflows/reusable_workflow.yaml) for multi-arch builds of type linux/amd64,linux/arm64.
 
 ## Arcaflow Container Toolkit as an Action
 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ jobs:
 * This workflow will automatically configure `IMAGE_TAG` to version if a release is detected.
 * This workflow will automatically configure `IMAGE_TAG` to the format `branch_commit-hash[0:7]` if a development branch is detected.
 * This workflow will automatically configure `QUAY_IMG_EXP` to 90 days if a development branch is detected.
-* Setting the `archetype` input will configure the `ARCHETYPE` env variable.
-* Setting the `multi_arch` input will configure the `REQ_CHECK_ONLY` env variable to True, thus allowing docker buildx to handle the build and push functionality in the [workflow](arcalot/arcaflow-containter-toolkit/.github/workflows/reusable_workflow.yaml) for multi-arch builds.
+* Setting the `archetype` input will configure the `ARCHETYPE` env variable.  
+* Setting the `multi_arch` input will configure the `REQ_CHECK_ONLY` env variable to True, thus allowing docker buildx to handle the build and push functionality in the [workflow](.github/workflows/reusable_workflow.yaml) for multi-arch builds.
 
 ## Arcaflow Container Toolkit as an Action
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ registries:
   `QUAY_CUSTOM_NAMESPACE` Quay Namespace to push image that is not QUAY_NAMESPACE - Default: ""  
   `QUAY_IMG_EXP` Image label to automatically expire in Quay - Default: "never"  
   `BUILD_TIMEOUT` Length of time before a build will fail in seconds - Default: 600  
+  `ARCHITYPES` Architecure(s) of image to build with - Default: ""
 
 #### Additional Information
 
 * `QUAY_IMG_EXP` more documentation and time formats can be found [here](https://docs.projectquay.io/use_quay.html#:~:text=Setting%20tag%20expiration%20from%20a%20Dockerfile)
 * `QUAY_CUSTOM_NAMESPACE` if set, will use in place of `QUAY_NAMESPACE`. More info [Arcaflow Container Toolkit and Reusable Workflows](#arcaflow-container-toolkit-and-reusable-workflows)
+* `ARCHITYPES` supports multiple architecture types. Pass multiple arguments as a single string with a space between. Architypes information can be found [here](https://docs.docker.com/build/building/multi-platform/)  
 
 ## Build Arcaflow Container Toolkit as an Executable Locally
 

--- a/internal/act/act.go
+++ b/internal/act/act.go
@@ -46,7 +46,7 @@ func ACT(build_img bool, push_img bool, cec ce_service.ContainerEngineService, c
 	}
 
 	if conf.Req_check_only {
-		logger.Infof("REQ_CHECK_ONLY requested disabling build and push through ACT")
+		logger.Infof("REQ_CHECK_ONLY requested disabling build and push through ACT. All requirements PASSED.")
 		return true, nil
 	}
 

--- a/internal/act/act.go
+++ b/internal/act/act.go
@@ -44,45 +44,25 @@ func ACT(build_img bool, push_img bool, cec ce_service.ContainerEngineService, c
 		QuayImgExp:            conf.Quay_Img_Exp,
 		BuildTimeLimitSeconds: conf.Build_Timeout,
 	}
-	if len(conf.Architypes) <= 1 {
-		architype := checkSingleArchitype(conf.Architypes)
-		if err := images.BuildImage(build_img, all_checks,
-			cec, abspath, conf.Image_Name, conf.Image_Tag, architype, &build_options,
-			logger); err != nil {
-			return false, err
-		}
-		for _, registry := range conf.Registries {
-			if err := images.PushImage(all_checks, build_img, push_img, cec, conf.Image_Name, conf.Image_Tag,
-				registry.Username, registry.Password, registry.Url, registry.Namespace, logger); err != nil {
-				logger.Errorf("(%w)", err)
-				return false, err
-			}
-		}
+
+	if conf.Req_check_only {
+		logger.Infof("REQ_CHECK_ONLY requested disabling build and push through ACT")
 		return true, nil
 	}
-	for i := 0; i < len(conf.Architypes); i++ {
-		conf.Image_Tag = ("manifest-" + conf.Architypes[i])
-		if err := images.BuildImage(build_img, all_checks, cec, abspath,
-			conf.Image_Name, conf.Image_Tag, conf.Architypes[i], &build_options,
-			logger); err != nil {
+
+	if err := images.BuildImage(build_img, all_checks,
+		cec, abspath, conf.Image_Name, conf.Image_Tag, conf.Archetype, &build_options,
+		logger); err != nil {
+		return false, err
+	}
+	for _, registry := range conf.Registries {
+		if err := images.PushImage(all_checks, build_img, push_img, cec, conf.Image_Name, conf.Image_Tag,
+			registry.Username, registry.Password, registry.Url, registry.Namespace, logger); err != nil {
+			logger.Errorf("(%w)", err)
 			return false, err
-		}
-		for _, registry := range conf.Registries {
-			if err := images.PushImage(all_checks, build_img, push_img, cec, conf.Image_Name, conf.Image_Tag,
-				registry.Username, registry.Password, registry.Url, registry.Namespace, logger); err != nil {
-				logger.Errorf("(%w)", err)
-				return false, err
-			}
 		}
 	}
 	return true, nil
-}
-
-func checkSingleArchitype(s []string) string {
-	if len(s) == 0 {
-		return ""
-	}
-	return s[0]
 }
 
 func AllTrue(checks []bool) bool {

--- a/internal/act/act.go
+++ b/internal/act/act.go
@@ -65,6 +65,17 @@ func ACT(build_img bool, push_img bool, cec ce_service.ContainerEngineService, c
 			}
 		}
 	}
+	if err := images.BuildImage(build_img, all_checks, cec, abspath, conf.Image_Name, image_tag, "", &build_options,
+		logger); err != nil {
+		return false, err
+	}
+	for _, registry := range conf.Registries {
+		if err := images.PushImage(all_checks, build_img, push_img, cec, conf.Image_Name, image_tag,
+			registry.Username, registry.Password, registry.Url, registry.Namespace, logger); err != nil {
+			logger.Errorf("(%w)", err)
+			return false, err
+		}
+	}
 	return true, nil
 }
 

--- a/internal/act/act.go
+++ b/internal/act/act.go
@@ -49,6 +49,20 @@ func ACT(build_img bool, push_img bool, cec ce_service.ContainerEngineService, c
 	architypes := conf.Architypes
 	fmt.Println(architypes)
 	image_tag := conf.Image_Tag
+	if len(architypes) == 0 {
+		if err := images.BuildImage(build_img, all_checks, cec, abspath, conf.Image_Name, image_tag, "", &build_options,
+			logger); err != nil {
+			return false, err
+		}
+		for _, registry := range conf.Registries {
+			if err := images.PushImage(all_checks, build_img, push_img, cec, conf.Image_Name, image_tag,
+				registry.Username, registry.Password, registry.Url, registry.Namespace, logger); err != nil {
+				logger.Errorf("(%w)", err)
+				return false, err
+			}
+		}
+		return true, nil
+	}
 	for i := 0; i < len(architypes); i++ {
 		if len(architypes) > 1 {
 			image_tag = ("manifest-" + architypes[i])
@@ -63,17 +77,6 @@ func ACT(build_img bool, push_img bool, cec ce_service.ContainerEngineService, c
 				logger.Errorf("(%w)", err)
 				return false, err
 			}
-		}
-	}
-	if err := images.BuildImage(build_img, all_checks, cec, abspath, conf.Image_Name, image_tag, "", &build_options,
-		logger); err != nil {
-		return false, err
-	}
-	for _, registry := range conf.Registries {
-		if err := images.PushImage(all_checks, build_img, push_img, cec, conf.Image_Name, image_tag,
-			registry.Username, registry.Password, registry.Url, registry.Namespace, logger); err != nil {
-			logger.Errorf("(%w)", err)
-			return false, err
 		}
 	}
 	return true, nil

--- a/internal/act/act.go
+++ b/internal/act/act.go
@@ -44,10 +44,10 @@ func ACT(build_img bool, push_img bool, cec ce_service.ContainerEngineService, c
 		QuayImgExp:            conf.Quay_Img_Exp,
 		BuildTimeLimitSeconds: conf.Build_Timeout,
 	}
-	fmt.Println(conf.Architypes)
 	if len(conf.Architypes) <= 1 {
+		architype := checkSingleArchitype(conf.Architypes)
 		if err := images.BuildImage(build_img, all_checks,
-			cec, abspath, conf.Image_Name, conf.Image_Tag, conf.Architypes[0], &build_options,
+			cec, abspath, conf.Image_Name, conf.Image_Tag, architype, &build_options,
 			logger); err != nil {
 			return false, err
 		}
@@ -76,6 +76,13 @@ func ACT(build_img bool, push_img bool, cec ce_service.ContainerEngineService, c
 		}
 	}
 	return true, nil
+}
+
+func checkSingleArchitype(s []string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	return s[0]
 }
 
 func AllTrue(checks []bool) bool {

--- a/internal/act/act.go
+++ b/internal/act/act.go
@@ -50,7 +50,8 @@ func ACT(build_img bool, push_img bool, cec ce_service.ContainerEngineService, c
 	fmt.Println(architypes)
 	image_tag := conf.Image_Tag
 	if len(architypes) == 0 {
-		if err := images.BuildImage(build_img, all_checks, cec, abspath, conf.Image_Name, image_tag, "", &build_options,
+		if err := images.BuildImage(build_img, all_checks,
+			cec, abspath, conf.Image_Name, image_tag, "", &build_options,
 			logger); err != nil {
 			return false, err
 		}
@@ -67,7 +68,8 @@ func ACT(build_img bool, push_img bool, cec ce_service.ContainerEngineService, c
 		if len(architypes) > 1 {
 			image_tag = ("manifest-" + architypes[i])
 		}
-		if err := images.BuildImage(build_img, all_checks, cec, abspath, conf.Image_Name, image_tag, architypes[i], &build_options,
+		if err := images.BuildImage(build_img, all_checks, cec, abspath,
+			conf.Image_Name, image_tag, architypes[i], &build_options,
 			logger); err != nil {
 			return false, err
 		}

--- a/internal/act/act.go
+++ b/internal/act/act.go
@@ -19,7 +19,6 @@ import (
 func ACT(build_img bool, push_img bool, cec ce_service.ContainerEngineService, conf dto.ACT, abspath string,
 	filenames []string, logger log.Logger,
 	pythonCodeStyleChecker func(abspath string, stdout *bytes.Buffer, logger log.Logger) error) (bool, error) {
-
 	meets_reqs := make([]bool, 3)
 	basic_reqs, err := requirements.BasicRequirements(filenames, logger)
 	if err != nil {
@@ -46,9 +45,9 @@ func ACT(build_img bool, push_img bool, cec ce_service.ContainerEngineService, c
 		BuildTimeLimitSeconds: conf.Build_Timeout,
 	}
 	fmt.Println(conf.Architypes)
-	if len(conf.Architypes) == 0 {
+	if len(conf.Architypes) <= 1 {
 		if err := images.BuildImage(build_img, all_checks,
-			cec, abspath, conf.Image_Name, conf.Image_Tag, "", &build_options,
+			cec, abspath, conf.Image_Name, conf.Image_Tag, conf.Architypes[0], &build_options,
 			logger); err != nil {
 			return false, err
 		}
@@ -62,9 +61,7 @@ func ACT(build_img bool, push_img bool, cec ce_service.ContainerEngineService, c
 		return true, nil
 	}
 	for i := 0; i < len(conf.Architypes); i++ {
-		if len(conf.Architypes) > 1 {
-			conf.Image_Tag = ("manifest-" + conf.Architypes[i])
-		}
+		conf.Image_Tag = ("manifest-" + conf.Architypes[i])
 		if err := images.BuildImage(build_img, all_checks, cec, abspath,
 			conf.Image_Name, conf.Image_Tag, conf.Architypes[i], &build_options,
 			logger); err != nil {

--- a/internal/act/act.go
+++ b/internal/act/act.go
@@ -45,18 +45,15 @@ func ACT(build_img bool, push_img bool, cec ce_service.ContainerEngineService, c
 		QuayImgExp:            conf.Quay_Img_Exp,
 		BuildTimeLimitSeconds: conf.Build_Timeout,
 	}
-
-	architypes := conf.Architypes
-	fmt.Println(architypes)
-	image_tag := conf.Image_Tag
-	if len(architypes) == 0 {
+	fmt.Println(conf.Architypes)
+	if len(conf.Architypes) == 0 {
 		if err := images.BuildImage(build_img, all_checks,
-			cec, abspath, conf.Image_Name, image_tag, "", &build_options,
+			cec, abspath, conf.Image_Name, conf.Image_Tag, "", &build_options,
 			logger); err != nil {
 			return false, err
 		}
 		for _, registry := range conf.Registries {
-			if err := images.PushImage(all_checks, build_img, push_img, cec, conf.Image_Name, image_tag,
+			if err := images.PushImage(all_checks, build_img, push_img, cec, conf.Image_Name, conf.Image_Tag,
 				registry.Username, registry.Password, registry.Url, registry.Namespace, logger); err != nil {
 				logger.Errorf("(%w)", err)
 				return false, err
@@ -64,17 +61,17 @@ func ACT(build_img bool, push_img bool, cec ce_service.ContainerEngineService, c
 		}
 		return true, nil
 	}
-	for i := 0; i < len(architypes); i++ {
-		if len(architypes) > 1 {
-			image_tag = ("manifest-" + architypes[i])
+	for i := 0; i < len(conf.Architypes); i++ {
+		if len(conf.Architypes) > 1 {
+			conf.Image_Tag = ("manifest-" + conf.Architypes[i])
 		}
 		if err := images.BuildImage(build_img, all_checks, cec, abspath,
-			conf.Image_Name, image_tag, architypes[i], &build_options,
+			conf.Image_Name, conf.Image_Tag, conf.Architypes[i], &build_options,
 			logger); err != nil {
 			return false, err
 		}
 		for _, registry := range conf.Registries {
-			if err := images.PushImage(all_checks, build_img, push_img, cec, conf.Image_Name, image_tag,
+			if err := images.PushImage(all_checks, build_img, push_img, cec, conf.Image_Name, conf.Image_Tag,
 				registry.Username, registry.Password, registry.Url, registry.Namespace, logger); err != nil {
 				logger.Errorf("(%w)", err)
 				return false, err

--- a/internal/ce_service/ce_service.go
+++ b/internal/ce_service/ce_service.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ContainerEngineService interface {
-	Build(filepath string, name string, tags []string, build_options *docker.BuildOptions) error
+	Build(filepath string, name string, tags []string, architype string, build_options *docker.BuildOptions) error
 	Tag(image_tag string, destination string) error
 	Push(destination string, username string, password string, registry_address string) error
 }

--- a/internal/ce_service/ce_service.go
+++ b/internal/ce_service/ce_service.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ContainerEngineService interface {
-	Build(filepath string, name string, tags []string, architype string, build_options *docker.BuildOptions) error
+	Build(filepath string, name string, tags []string, archetype string, build_options *docker.BuildOptions) error
 	Tag(image_tag string, destination string) error
 	Push(destination string, username string, password string, registry_address string) error
 }

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -43,7 +43,7 @@ func NewCEClient() (*CEClient, error) {
 	}, nil
 }
 
-func (ce CEClient) Build(filepath string, name string, tags []string, build_options *BuildOptions) error {
+func (ce CEClient) Build(filepath string, name string, tags []string, architype string, build_options *BuildOptions) error {
 	image_tag := name + ":" + tags[0]
 	quay_img_exp_value := map[string]string{
 		"quay.expires-after": build_options.QuayImgExp,
@@ -59,6 +59,7 @@ func (ce CEClient) Build(filepath string, name string, tags []string, build_opti
 		Dockerfile: "Dockerfile",
 		Tags:       []string{image_tag},
 		Labels:     quay_img_exp_value,
+		Platform:   architype,
 	}
 	res, err := ce.Client.ImageBuild(ctx, tar, opts)
 	if err != nil {

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -43,7 +43,7 @@ func NewCEClient() (*CEClient, error) {
 	}, nil
 }
 
-func (ce CEClient) Build(filepath string, name string, tags []string, architype string, build_options *BuildOptions) error {
+func (ce CEClient) Build(filepath string, name string, tags []string, archetype string, build_options *BuildOptions) error {
 	image_tag := name + ":" + tags[0]
 	quay_img_exp_value := map[string]string{
 		"quay.expires-after": build_options.QuayImgExp,
@@ -59,7 +59,7 @@ func (ce CEClient) Build(filepath string, name string, tags []string, architype 
 		Dockerfile: "Dockerfile",
 		Tags:       []string{image_tag},
 		Labels:     quay_img_exp_value,
-		Platform:   architype,
+		Platform:   archetype,
 	}
 	res, err := ce.Client.ImageBuild(ctx, tar, opts)
 	if err != nil {

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -31,7 +31,7 @@ func TestClient_BuildImage(t *testing.T) {
 	}
 
 	assert.Error(t, client.Build("some", "path", []string{"tag1", "tag2"},
-		docker.DefaultBuildOptions()))
+		"amd64", docker.DefaultBuildOptions()))
 }
 
 func TestClient_ImageTag(t *testing.T) {

--- a/internal/dto/act.go
+++ b/internal/dto/act.go
@@ -15,6 +15,7 @@ type ACT struct {
 	Image_Tag        string `default:"latest"`
 	Quay_Img_Exp     string `default:"never"`
 	Build_Timeout    uint32 `default:"600"`
+	Architypes       []string
 	Registries       []Registry
 }
 
@@ -34,6 +35,7 @@ func Unmarshal(push bool, logger log.Logger) (ACT, error) {
 		Image_Tag:        viper.GetString("image_tag"),
 		Quay_Img_Exp:     viper.GetString("quay_img_exp"),
 		Build_Timeout:    viper.GetUint32("build_timeout"),
+		Architypes:       viper.GetStringSlice("architypes"),
 		Registries:       registries}
 	if err := defaults.Set(&conf); err != nil {
 		return ACT{}, fmt.Errorf("error setting defaults (%w)", err)

--- a/internal/dto/act.go
+++ b/internal/dto/act.go
@@ -15,7 +15,8 @@ type ACT struct {
 	Image_Tag        string `default:"latest"`
 	Quay_Img_Exp     string `default:"never"`
 	Build_Timeout    uint32 `default:"600"`
-	Architypes       []string
+	Archetype        string
+	Req_check_only   bool
 	Registries       []Registry
 }
 
@@ -35,7 +36,8 @@ func Unmarshal(push bool, logger log.Logger) (ACT, error) {
 		Image_Tag:        viper.GetString("image_tag"),
 		Quay_Img_Exp:     viper.GetString("quay_img_exp"),
 		Build_Timeout:    viper.GetUint32("build_timeout"),
-		Architypes:       viper.GetStringSlice("architypes"),
+		Archetype:        viper.GetString("archetype"),
+		Req_check_only:   viper.GetBool("req_check_only"),
 		Registries:       registries}
 	if err := defaults.Set(&conf); err != nil {
 		return ACT{}, fmt.Errorf("error setting defaults (%w)", err)

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -9,12 +9,12 @@ import (
 )
 
 func BuildImage(build_img bool, all_checks bool, cec ce_service.ContainerEngineService, abspath string, image_name string,
-	image_tag string, options *docker.BuildOptions, logger log.Logger) error {
+	image_tag string, architype string, options *docker.BuildOptions, logger log.Logger) error {
 
 	if all_checks && build_img {
 		logger.Infof("Passed all requirements: %s %s\n", image_name, image_tag)
 		logger.Infof("Building %s %s from %v\n", image_name, image_tag, abspath)
-		if err := cec.Build(abspath, image_name, []string{image_tag}, options); err != nil {
+		if err := cec.Build(abspath, image_name, []string{image_tag}, architype, options); err != nil {
 			return err
 		}
 	}

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -9,12 +9,12 @@ import (
 )
 
 func BuildImage(build_img bool, all_checks bool, cec ce_service.ContainerEngineService, abspath string, image_name string,
-	image_tag string, architype string, options *docker.BuildOptions, logger log.Logger) error {
+	image_tag string, archetype string, options *docker.BuildOptions, logger log.Logger) error {
 
 	if all_checks && build_img {
 		logger.Infof("Passed all requirements: %s %s\n", image_name, image_tag)
 		logger.Infof("Building %s %s from %v\n", image_name, image_tag, abspath)
-		if err := cec.Build(abspath, image_name, []string{image_tag}, architype, options); err != nil {
+		if err := cec.Build(abspath, image_name, []string{image_tag}, archetype, options); err != nil {
 			return err
 		}
 	}

--- a/internal/images/images_test.go
+++ b/internal/images/images_test.go
@@ -19,10 +19,10 @@ func TestBuildImage(t *testing.T) {
 	defer ctrl.Finish()
 	cec := mocks.NewMockContainerEngineService(ctrl)
 	cec.EXPECT().
-		Build("use", "the", []string{"forks"}, docker.DefaultBuildOptions()).
+		Build("use", "the", []string{"forks"}, "amd64", docker.DefaultBuildOptions()).
 		Return(nil).
 		Times(1)
-	assert.Nil(t, images.BuildImage(true, true, cec, "use", "the", "forks", docker.DefaultBuildOptions(), logger))
+	assert.Nil(t, images.BuildImage(true, true, cec, "use", "the", "forks", "amd64", docker.DefaultBuildOptions(), logger))
 }
 
 func TestPushImage(t *testing.T) {

--- a/internal/requirements/containerfile.go
+++ b/internal/requirements/containerfile.go
@@ -38,7 +38,7 @@ func ContainerfileRequirements(abspath string, logger log.Logger) (bool, error) 
 
 		// create map of regexp patterns to search for in Dockerfile as well as log information if not found
 		m := map[string]string{
-			// "FROM quay\\.io/(centos/centos:stream8|arcalot/arcaflow-plugin-baseimage-python-.*base)": "Dockerfile doesn't use a supported base image\n",
+			"FROM quay\\.io/(centos/centos:stream8|arcalot/arcaflow-plugin-baseimage-python-.*base)": "Dockerfile doesn't use a supported base image\n",
 			"(ADD|COPY) .*/?LICENSE /.*": "Dockerfile does not contain copy of arcaflow plugin license\n",
 			"CMD \\[\\]":                 "Dockerfile does not contain an empty command (i.e. CMD [])",
 			"LABEL org.opencontainers.image.source=\".*\"":                                     "Dockerfile is missing LABEL org.opencontainers.image.source",

--- a/internal/requirements/containerfile.go
+++ b/internal/requirements/containerfile.go
@@ -1,10 +1,11 @@
 package requirements
 
 import (
-	"go.arcalot.io/log"
 	"os"
 	"path/filepath"
 	"regexp"
+
+	"go.arcalot.io/log"
 )
 
 func ContainerfileRequirements(abspath string, logger log.Logger) (bool, error) {
@@ -37,7 +38,7 @@ func ContainerfileRequirements(abspath string, logger log.Logger) (bool, error) 
 
 		// create map of regexp patterns to search for in Dockerfile as well as log information if not found
 		m := map[string]string{
-			"FROM quay\\.io/(centos/centos:stream8|arcalot/arcaflow-plugin-baseimage-python-.*base)": "Dockerfile doesn't use a supported base image\n",
+			// "FROM quay\\.io/(centos/centos:stream8|arcalot/arcaflow-plugin-baseimage-python-.*base)": "Dockerfile doesn't use a supported base image\n",
 			"(ADD|COPY) .*/?LICENSE /.*": "Dockerfile does not contain copy of arcaflow plugin license\n",
 			"CMD \\[\\]":                 "Dockerfile does not contain an empty command (i.e. CMD [])",
 			"LABEL org.opencontainers.image.source=\".*\"":                                     "Dockerfile is missing LABEL org.opencontainers.image.source",

--- a/mocks/ce_service/ce_service.go
+++ b/mocks/ce_service/ce_service.go
@@ -35,17 +35,17 @@ func (m *MockContainerEngineService) EXPECT() *MockContainerEngineServiceMockRec
 }
 
 // Build mocks base method.
-func (m *MockContainerEngineService) Build(arg0, arg1 string, arg2 []string, arg3 *docker.BuildOptions) error {
+func (m *MockContainerEngineService) Build(arg0, arg1 string, arg2 []string, arg3 string, arg4 *docker.BuildOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Build", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Build", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Build indicates an expected call of Build.
-func (mr *MockContainerEngineServiceMockRecorder) Build(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockContainerEngineServiceMockRecorder) Build(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockContainerEngineService)(nil).Build), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockContainerEngineService)(nil).Build), arg0, arg1, arg2, arg3, arg4)
 }
 
 // Push mocks base method.


### PR DESCRIPTION
## Changes introduced with this PR

- Enhanced ACT to provide the docker build option `platform` to select which archetype to build the image with.
- Enhanced ACT workflow to turn off build and push if multi_arch is requested as the docker client currently does not have a way of creating either manifests, or multi_arch images like docker buildx (CLI tool) can. This functionality, only when requested, will build and push using docker buildx to build and push images similar to the way ACT currently does with it's client. ACT will still run and valid requirements before proceeding.

Overall, these changes will provide the ability to not only build a requested archetype locally or with CI, but also will give the users who consume ACT through a workflow the ability to build multi-arch images. The defaults will continue to work as ACT does today requiring no change to current workflows. Only extended capabilities. 

This PR will additionally be tied to the ACT action PR [here](https://github.com/arcalot/arcaflow-container-toolkit-action/pull/6) as a new release of the action itself will need to be done at the same time these changes are made into a release.

Tests can be seen with the workflows here:

Workflow's use as of today [test](https://github.com/jdowni000/arcaflow-plugin-template-python/actions/runs/6111515493)
Workflow with multi_arch enabled [test](https://github.com/jdowni000/arcaflow-plugin-template-python/actions/runs/6110311516/job/16585794206)
Workflow with single archetype requested [test](https://github.com/jdowni000/arcaflow-plugin-template-python/actions/runs/6111556514)

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).