### PR TITLE
Fix Tag scenarios

### DIFF
--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -102,7 +102,7 @@ jobs:
           labels: quay.expires-after=${{ env.QUAY_IMG_EXP }}
 
       - name: Build and push multi-arch image for release
-        if: $ {{ inputs.multi_arch}} && github.event_name == 'release'
+        if: ${{ inputs.multi_arch}} && github.event_name == 'release'
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -85,6 +85,14 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+      
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}"
+          labels: |
+            quay.expires-after=${{ env.QUAY_IMG_EXP }}
 
       - name: Build and push for Multi-Arch
         if: ${{ inputs.multi_arch }}
@@ -94,5 +102,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}"
-          labels: |
-            "quay.expires-after=${{ env.QUAY_IMG_EXP }}"
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -104,8 +104,8 @@ jobs:
       - name: Build and push multi-arch image for release
         if: $ {{ inputs.multi_arch}} && github.event_name == 'release'
         uses: docker/build-push-action@v4
-          with:
-            context: .
-            platforms: linux/amd64,linux/arm64
-            push: true
-            tags: quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}, quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:latest
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}, quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:latest

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -94,4 +94,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}"
-          labels: quay.expires-after=${{ env.QUAY_IMG_EXP }}
+          labels: 
+            - "quay.expires-after=${{ env.QUAY_IMG_EXP }}"

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -47,7 +47,6 @@ jobs:
       - name: Set image tag for main
         if: github.ref == 'refs/heads/main' && github.event_name != 'release'
         run: |
-          export commit_hash=${{ github.sha }}
           echo "IMAGE_TAG=main_latest" >> $GITHUB_ENV
 
       - name: Set image tag and expiration for dev

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -91,6 +91,16 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
+      - name: Build and push multi-arch image for release
+        if: github.event_name == 'release' && ${{ inputs.multi_arch}}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }},
+            quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:latest
+
       - name: Build and push multi-arch image
         if: ${{ inputs.multi_arch }} && github.event_name != 'release'
         uses: docker/build-push-action@v4
@@ -100,12 +110,3 @@ jobs:
           push: true
           tags: quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}
           labels: quay.expires-after=${{ env.QUAY_IMG_EXP }}
-
-      - name: Build and push multi-arch image for release
-        if: ${{ inputs.multi_arch}} && github.event_name == 'release'
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}, quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:latest

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -92,8 +92,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build and push multi-arch image for release
-        if: github.event_name == 'release'
-        if: ${{ inputs.multi_arch }}
+        if: github.event_name == 'release' && ${{ inputs.multi_arch}} == true
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -103,8 +102,7 @@ jobs:
             quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:latest
 
       - name: Build and push multi-arch image
-        if: github.event_name != 'release'
-        if: ${{ inputs.multi_arch }}
+        if: github.event_name != 'release' && ${{ inputs.multi_arch }} == true
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -85,12 +85,6 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          labels: |
-            quay.expires-after=${{ env.QUAY_IMG_EXP }}
 
       - name: Build and push for Multi-Arch
         if: ${{ inputs.multi_arch }}
@@ -100,4 +94,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}"
-          labels: ${{ steps.meta.labels }}
+          labels: |
+            "quay.expires-after=${{ env.QUAY_IMG_EXP }}"

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -94,4 +94,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}"
-          labels: ${{ env.QUAY_IMG_EXP }}
+          labels: "quay.expires-after=${{ env.QUAY_IMG_EXP }}"

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -92,7 +92,8 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build and push multi-arch image for release
-        if: github.event_name == 'release' && ${{ inputs.multi_arch}} == 1
+        if: github.event_name == 'release'
+        if: ${{ inputs.multi_arch }}
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -102,7 +103,8 @@ jobs:
             quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:latest
 
       - name: Build and push multi-arch image
-        if: github.event_name != 'release' && ${{ inputs.multi_arch }} == 1
+        if: github.event_name != 'release'
+        if: ${{ inputs.multi_arch }}
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -85,14 +85,6 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-      
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}"
-          labels: |
-            quay.expires-after=${{ env.QUAY_IMG_EXP }}
 
       - name: Build and push for Multi-Arch
         if: ${{ inputs.multi_arch }}
@@ -102,4 +94,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}"
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: quay.expires-after=${{ env.QUAY_IMG_EXP }}

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -34,6 +34,10 @@ on:
       QUAY_PASSWORD:
         required: false
 
+ENV:
+  IMAGE_NAME: ${{ inputs.image_name }}
+  IMAGE_TAG: ${{ inputs.image_tag }}
+
 jobs:
   act-build:
     name: Build ${{ github.ref_name }} from ${{ github.event_name }}
@@ -93,4 +97,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ inputs.image_tag }}"
+          tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/$IMAGE_NAME:$IMAGE_TAG"

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -40,17 +40,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set image tag for release
-        if: github.event_name == 'release'
+        if: github.event_name == release
         run: |
           echo "IMAGE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       
       - name: Set image tag for main
-        if: github.ref == 'refs/heads/main' && github.event_name != 'release'
+        if: github.ref == 'refs/heads/main' && github.event_name != release
         run: |
           echo "IMAGE_TAG=main_latest" >> $GITHUB_ENV
 
       - name: Set image tag and expiration for dev
-        if: github.ref != 'refs/heads/main' && github.event_name != 'release'
+        if: github.ref != 'refs/heads/main' && github.event_name != release
         run: |
           export commit_hash=${{ github.sha }}
           echo "IMAGE_TAG=${GITHUB_REF##*/}_${commit_hash:0:7}" >> $GITHUB_ENV
@@ -92,7 +92,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build and push multi-arch image for release
-        if: github.event_name == 'release' && ${{ inputs.multi_arch}}
+        if: github.event_name == release && ${{ inputs.multi_arch}}
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -102,7 +102,7 @@ jobs:
             quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:latest
 
       - name: Build and push multi-arch image
-        if: ${{ inputs.multi_arch }} && github.event_name != 'release'
+        if: github.event_name != release && ${{ inputs.multi_arch }}
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -94,5 +94,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}"
-          labels: 
-            - "quay.expires-after=${{ env.QUAY_IMG_EXP }}"
+          labels: quay.expires-after=${{ env.QUAY_IMG_EXP }}

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -94,3 +94,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}"
+          labels: ${{ env.QUAY_IMG_EXP }}

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -79,11 +79,11 @@ jobs:
           archetype: ${{ inputs.archetype }}
           req_check_only: ${{ inputs.multi_arch }}
 
-      - name: Set up Docker Buildx for Multi-Arch
+      - name: Set up Docker Buildx for multi-arch
         if: ${{ inputs.multi_arch }}
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to Quay for Multi-Arch
+      - name: Login to Quay for multi-arch
         if: ${{ inputs.multi_arch }}
         uses: docker/login-action@v2
         with:
@@ -91,12 +91,21 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Build and push for Multi-Arch
-        if: ${{ inputs.multi_arch }}
+      - name: Build and push multi-arch image
+        if: ${{ inputs.multi_arch }} && github.event_name != 'release'
         uses: docker/build-push-action@v4
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}"
+          tags: quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}
           labels: quay.expires-after=${{ env.QUAY_IMG_EXP }}
+
+      - name: Build and push multi-arch image for release
+        if: $ {{ inputs.multi_arch}} && github.event_name == 'release'
+        uses: docker/build-push-action@v4
+          with:
+            context: .
+            platforms: linux/amd64,linux/arm64
+            push: true
+            tags: quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}, quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:latest

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -92,7 +92,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build and push multi-arch image for release
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && ${{ inputs.multi_arch}} == 1
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -102,7 +102,7 @@ jobs:
             quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:latest
 
       - name: Build and push multi-arch image
-        if: github.event_name != 'release'
+        if: github.event_name != 'release' && ${{ inputs.multi_arch }} == 1
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -44,6 +44,12 @@ jobs:
         run: |
           echo "IMAGE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       
+      - name: Set image tag for main
+        if: github.ref == 'refs/heads/main' && github.event_name != 'release'
+        run: |
+          export commit_hash=${{ github.sha }}
+          echo "IMAGE_TAG=main_latest" >> $GITHUB_ENV
+
       - name: Set image tag and expiration for dev
         if: github.ref != 'refs/heads/main' && github.event_name != 'release'
         run: |

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -40,17 +40,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set image tag for release
-        if: github.event_name == release
+        if: github.event_name == 'release'
         run: |
           echo "IMAGE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       
       - name: Set image tag for main
-        if: github.ref == 'refs/heads/main' && github.event_name != release
+        if: github.ref == 'refs/heads/main' && github.event_name != 'release'
         run: |
           echo "IMAGE_TAG=main_latest" >> $GITHUB_ENV
 
       - name: Set image tag and expiration for dev
-        if: github.ref != 'refs/heads/main' && github.event_name != release
+        if: github.ref != 'refs/heads/main' && github.event_name != 'release'
         run: |
           export commit_hash=${{ github.sha }}
           echo "IMAGE_TAG=${GITHUB_REF##*/}_${commit_hash:0:7}" >> $GITHUB_ENV
@@ -92,7 +92,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build and push multi-arch image for release
-        if: github.event_name == release && ${{ inputs.multi_arch}}
+        if: github.event_name == 'release'
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -102,7 +102,7 @@ jobs:
             quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:latest
 
       - name: Build and push multi-arch image
-        if: github.event_name != release && ${{ inputs.multi_arch }}
+        if: github.event_name != 'release'
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -85,6 +85,12 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          labels: |
+            quay.expires-after=${{ env.QUAY_IMG_EXP }}
 
       - name: Build and push for Multi-Arch
         if: ${{ inputs.multi_arch }}
@@ -94,4 +100,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}"
-          labels: "quay.expires-after=${{ env.QUAY_IMG_EXP }}"
+          labels: ${{ steps.meta.labels }}

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -34,10 +34,6 @@ on:
       QUAY_PASSWORD:
         required: false
 
-ENV:
-  IMAGE_NAME: ${{ inputs.image_name }}
-  IMAGE_TAG: ${{ inputs.image_tag }}
-
 jobs:
   act-build:
     name: Build ${{ github.ref_name }} from ${{ github.event_name }}

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -93,4 +93,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/$IMAGE_NAME:$IMAGE_TAG"
+          tags: "quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}"

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -92,7 +92,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build and push multi-arch image for release
-        if: ${{ github.event_name == 'release' }} && ${{ inputs.multi_arch}}
+        if: github.event_name == 'release' && inputs.multi_arch == true
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -102,7 +102,7 @@ jobs:
             quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:latest
 
       - name: Build and push multi-arch image
-        if: ${{ github.event_name != 'release' }} && ${{ inputs.multi_arch }}
+        if: github.event_name != 'release' && inputs.multi_arch == true
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -92,7 +92,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build and push multi-arch image for release
-        if: github.event_name == 'release' && ${{ inputs.multi_arch}} == true
+        if: ${{ github.event_name == 'release' }} && ${{ inputs.multi_arch}}
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -102,7 +102,7 @@ jobs:
             quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:latest
 
       - name: Build and push multi-arch image
-        if: github.event_name != 'release' && ${{ inputs.multi_arch }} == true
+        if: ${{ github.event_name != 'release' }} && ${{ inputs.multi_arch }}
         uses: docker/build-push-action@v4
         with:
           context: .


### PR DESCRIPTION
## Changes introduced with this PR

- Fix tagging issues for dev branches
- Tag main branch now as `main_latest`
- Tag release image with release tag and latest tag

Test for release [here](https://github.com/jdowni000/arcaflow-plugin-template-python/actions/runs/6159511775/job/16718059908)
Test for main branch [here](https://github.com/jdowni000/arcaflow-plugin-template-python/actions/runs/6150297648/job/16718133829)
Test for dev branch [here](https://github.com/jdowni000/arcaflow-plugin-template-python/actions/runs/6147731382/job/16718249832)
Test for single archetype using ACT [here](https://github.com/jdowni000/arcaflow-plugin-template-python/actions/runs/6160801233/job/16718571811)

Test repository for push [here](https://quay.io/repository/jdownie/arcaflow-plugin-template-python?tab=tags)

Worth noting as well that there is an issue with quay's repository not seeing the labels of an image with multi-arch builds. I have confirmed this with Jared, that the label `quay.expires-after=90d` is making it to the dev images. However, it is not being set in the repository to actually expire. I will raise an issue with quay itself. 

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).