### PR TITLE
updating reusable workflow to use buildah for multi-arch builds

### DIFF
--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -37,6 +37,7 @@ on:
 env:
   QUAY_TAG_ROOT: quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}
   QUAY_IMG_EXP: 0
+  BUILD_PLATFORMS: linux/amd64, linux/arm64
 
 jobs:
   act-build:
@@ -98,7 +99,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           context: .
-          platforms: linux/amd64, linux/arm64
+          platforms: ${{ env.BUILD_PLATFORMS }}
           tags: ${{ env.IMAGE_TAGS }}
           containerfiles: |
             ./Dockerfile

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -34,33 +34,34 @@ on:
       QUAY_PASSWORD:
         required: false
 
+env:
+  QUAY_TAG_ROOT: quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}
+  QUAY_IMG_EXP: 0
+
 jobs:
   act-build:
     name: Build ${{ github.ref_name }} from ${{ github.event_name }}
     runs-on: ubuntu-latest
     steps:
-      - name: Set image tag for release
+      - name: Set image tags for release
         if: github.event_name == 'release'
         run: |
-          echo "IMAGE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "IMAGE_TAGS=${{ env.QUAY_TAG_ROOT }}:${GITHUB_REF#refs/*/} ${{ env.QUAY_TAG_ROOT }}:latest" >> $GITHUB_ENV
       
-      - name: Set image tag for main
+      - name: Set image tags for main
         if: github.ref == 'refs/heads/main' && github.event_name != 'release'
         run: |
-          echo "IMAGE_TAG=main_latest" >> $GITHUB_ENV
+          echo "IMAGE_TAGS=${{ env.QUAY_TAG_ROOT }}:main_latest" >> $GITHUB_ENV
 
-      - name: Set image tag and expiration for dev
+      - name: Set image tags and expiration for dev
         if: github.ref != 'refs/heads/main' && github.event_name != 'release'
         run: |
           export commit_hash=${{ github.sha }}
-          echo "IMAGE_TAG=${GITHUB_REF##*/}_${commit_hash:0:7}" >> $GITHUB_ENV
           echo "QUAY_IMG_EXP=90d" >> $GITHUB_ENV
+          echo "IMAGE_TAGS=${{ env.QUAY_TAG_ROOT }}:${GITHUB_REF##*/}_${commit_hash:0:7}" >> $GITHUB_ENV
       
       - name: Checkout this project
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
         
       - name: arcaflow-container-toolkit-action
         uses: arcalot/arcaflow-container-toolkit-action@v1.3.0
@@ -79,34 +80,32 @@ jobs:
           archetype: ${{ inputs.archetype }}
           req_check_only: ${{ inputs.multi_arch }}
 
-      - name: Set up Docker Buildx for multi-arch
-        if: ${{ inputs.multi_arch }}
-        uses: docker/setup-buildx-action@v3
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
 
-      - name: Login to Quay for multi-arch
+      - name: Log in to quay.io for multi-arch
         if: ${{ inputs.multi_arch }}
-        uses: docker/login-action@v3
+        uses: redhat-actions/podman-login@v1
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-
-      - name: Build and push multi-arch image for release
-        if: github.event_name == 'release' && inputs.multi_arch == true
-        uses: docker/build-push-action@v5
+      
+      - name: Build multi-arch image
+        id: build-multi-arch
+        uses: redhat-actions/buildah-build@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }},
-            quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:latest
-
-      - name: Build and push multi-arch image
-        if: github.event_name != 'release' && inputs.multi_arch == true
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: quay.io/${{ secrets.QUAY_NAMESPACE }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}
+          platforms: linux/amd64, linux/arm64
+          tags: ${{ env.IMAGE_TAGS }}
+          containerfiles: |
+            ./Dockerfile
           labels: quay.expires-after=${{ env.QUAY_IMG_EXP }}
+      
+      - name: Push image to quay.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-multi-arch.outputs.image }}
+          tags: ${{ steps.build-multi-arch.outputs.tags }}


### PR DESCRIPTION
## Changes introduced with this PR

Currently our multi-arch builds to not properly set expiration dates in quay.io. It was suggested that we try `buildah` in place of `docker buildx`, so this is an attempt at that change.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).