### PR TITLE
Tweak the CI workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,12 +2,10 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - "**"
+      - "main"
     tags:
-      - "**"
+      - "v*"
   pull_request:
-env:
-  go_version: 1.21.6
 jobs:
   golangci-lint:
     name: golangci-lint
@@ -18,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.go_version }}
+          go-version: ${{ vars.ARCALOT_GO_VERSION }}
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
@@ -33,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.go_version }}
+          go-version: ${{ vars.ARCALOT_GO_VERSION }}
 
       - name: Set up gotestfmt
         uses: gotesttools/gotestfmt-action@v2
@@ -96,7 +94,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.go_version }}
+          go-version: ${{ vars.ARCALOT_GO_VERSION }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## Changes introduced with this PR

This PR makes some tweaks to the CI workflow:
- Change the triggers to only the `main` branch and `v*` tags so that the CI runs only once on PR updates (which is what we do in other repos).
- Obtain the Go version from the organization variable instead of defining it locally.

I'm deferring converting this to using the reusable workflow until I can get some answers about the `limgo` GHA.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).