### PR TITLE
Update limgo-action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up limgo
-        uses: GoTestTools/limgo-action@v1.0.1
+        uses: GoTestTools/limgo-action@v1.0.2
         with:
           version: "v1.0.0"
           install-only: true


### PR DESCRIPTION
## Changes introduced with this PR

This change updates the version of the `limgo-action` GH Action used by the CI.  The previous version was using Node.js 16, which is now deprecated; the new version of the Action uses the current version of Node.js.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).