### PR TITLE
Use common reusable Go workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,120 +2,28 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - "main"
+      - main
     tags:
-      - "v*"
+      - v*
   pull_request:
 jobs:
-  golangci-lint:
-    name: golangci-lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ vars.ARCALOT_GO_VERSION }}
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: v1.55.2
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ vars.ARCALOT_GO_VERSION }}
-
-      - name: Set up gotestfmt
-        uses: gotesttools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up limgo
-        uses: GoTestTools/limgo-action@v1.0.2
-        with:
-          version: "v1.0.0"
-          install-only: true
-
-      - name: Setup go mockgen
-        run: go install go.uber.org/mock/mockgen@v0.4.0
-
-      - name: generate mocks
-        run: go generate ./...
-
-      - name: run tests
-        run: |
-          set -euo pipefail
-          go test -coverprofile=test.cov -json -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
-
-      - name: upload test log
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: test-log
-          path: /tmp/gotest.log
-          if-no-files-found: error
-
-      - name: Calculate test coverage
-        run: |
-          cat .limgo.json
-          limgo -coverfile=test.cov -config=.limgo.json -outfmt=md -outfile=limgo_cov.md
-          cat limgo_cov.md >> $GITHUB_STEP_SUMMARY
-
-      - name: upload coverage results
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage
-          path: limgo_cov.md
-          if-no-files-found: error
+  lint_and_test:
+    name: lint and test
+    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_lint_and_test.yaml@update-go-lint-and-test  # FIXME:  SHOULD BE @main
+    with:
+      go_version: ${{ vars.ARCALOT_GO_VERSION }}
 
   release:
     name: release
-    runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
     needs:
-      - golangci-lint
-      - test
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ vars.ARCALOT_GO_VERSION }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Release if tagged, else Build
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: latest
-          args: ${{ env.GR_CMD }} ${{ env.GR_ARGS }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GR_CMD: ${{ startsWith(github.event.ref, 'refs/tags/') && 'release' || 'build' }}
-          GR_ARGS: ${{ startsWith(github.event.ref, 'refs/tags/') && '--clean' || '--snapshot' }}
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: binaries
-          path: dist
+      - lint_and_test
+    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_release.yaml@update-go-lint-and-test  # FIXME:  SHOULD BE @main
+    secrets:
+      REGISTRY_USERNAME: ${{ github.actor }}
+      REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      go_version: ${{ vars.ARCALOT_GO_VERSION }}
+      for_release: ${{ startsWith(github.event.ref, 'refs/tags/') }}
+      registry: ghcr.io

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint_and_test:
     name: lint and test
-    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_lint_and_test.yaml@update-go-lint-and-test  # FIXME:  SHOULD BE @main
+    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_lint_and_test.yaml@main
     with:
       go_version: ${{ vars.ARCALOT_GO_VERSION }}
 
@@ -20,7 +20,7 @@ jobs:
       packages: write
     needs:
       - lint_and_test
-    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_release.yaml@update-go-lint-and-test  # FIXME:  SHOULD BE @main
+    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_release.yaml@main
     secrets:
       REGISTRY_USERNAME: ${{ github.actor }}
       REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,7 @@ jobs:
     name: release
     permissions:
       contents: write
+      packages: write
     needs:
       - lint_and_test
     uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_release.yaml@update-go-lint-and-test  # FIXME:  SHOULD BE @main

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
 project_name: arcaflow-container-toolkit
 before:
   hooks:


### PR DESCRIPTION
## Changes introduced with this PR

This PR reworks the CI to use the common reusable Go workflows provided in https://github.com/arcalot/arcaflow-reusable-workflows/pull/24.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).