### PR TITLE
Since the push is unconditional, make login match

### DIFF
--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -86,8 +86,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
 
-      - name: Log in to quay.io for multi-arch
-        if: ${{ inputs.multi_arch }}
+      - name: Log in to quay.io
         uses: redhat-actions/podman-login@v1
         with:
           registry: quay.io


### PR DESCRIPTION
## Changes introduced with this PR

The `reusable_workflow.yaml` workflow unconditionally pushes the container image to Quay; however, it currently only performs a login if the `multi_arch` is `true`.  This means that, if `multi_arch` is `false`, the workflow will presumably fail  (as the CI for https://github.com/arcalot/arcaflow-plugin-aws-ec2-control/pull/50 currently does).  (@dustinblack, @jdowni000:  I'm curious as to how/why the code evolved to this state.)

This change removes the conditional from the login step:  just as we unconditionally build and push the image, we will now unconditionally log in, first.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).