### PR TITLE
Add label_validation config, migrate to golangci-lint v2, update Go to 1.25

### DIFF
--- a/.act.yaml
+++ b/.act.yaml
@@ -5,6 +5,7 @@ project_filepath: /github/workspace
 quay_exp: 'never'
 archetype: ''
 req_check_only: false
+label_validation: strict
 registries:
   - url: quay.io
     username_envvar: "QUAY_USERNAME"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -96,11 +96,6 @@ linters:
         # We don't care about variable shadowing.
         - shadow
         - fieldalignment
-    stylecheck:
-      checks:
-        - all
 formatters:
   enable:
     - gofmt
-issues:
-  exclude-use-default: false

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,4 @@
+version: "2"
 run:
   timeout: 5m
 linters:
@@ -57,8 +58,6 @@ linters:
     - dogsled
     # Enforce consistent import aliases across all files.
     - importas
-    # Make code properly formatted.
-    - gofmt
     # Prevent faulty error checks.
     - nilerr
     # Prevent direct error checks that won't work with wrapped errors.
@@ -71,34 +70,37 @@ linters:
     - testpackage
 
     # endregion
-linters-settings:
-  revive:
-    severity: error
-  depguard:
-    rules:
-      main:
-        list-mode: strict
-        allow:
-          - $gostd
-          - go.flow.arcalot.io/
-          - go.arcalot.io/
-          - gopkg.in/yaml.v3
-          - github.com/arcalot/arcaflow-container-toolkit
-          - github.com/docker/docker
-          - github.com/spf13/viper
-          - github.com/spf13/cobra
-          - github.com/creasty/defaults
-          - github.com/moby
-          - go.uber.org/mock/gomock
-          - github.com/golang/mock/gomock
-  govet:
-    enable-all: true
-    disable:
-      # We don't care about variable shadowing.
-      - shadow
-      - fieldalignment
-  stylecheck:
-    checks:
-      - all
+  settings:
+    revive:
+      severity: error
+    depguard:
+      rules:
+        main:
+          list-mode: strict
+          allow:
+            - $gostd
+            - go.flow.arcalot.io/
+            - go.arcalot.io/
+            - gopkg.in/yaml.v3
+            - github.com/arcalot/arcaflow-container-toolkit
+            - github.com/docker/docker
+            - github.com/spf13/viper
+            - github.com/spf13/cobra
+            - github.com/creasty/defaults
+            - github.com/moby
+            - go.uber.org/mock/gomock
+            - github.com/golang/mock/gomock
+    govet:
+      enable-all: true
+      disable:
+        # We don't care about variable shadowing.
+        - shadow
+        - fieldalignment
+    stylecheck:
+      checks:
+        - all
+formatters:
+  enable:
+    - gofmt
 issues:
   exclude-use-default: false

--- a/fixtures/no_labels/Dockerfile
+++ b/fixtures/no_labels/Dockerfile
@@ -1,0 +1,12 @@
+FROM quay.io/centos/centos:stream8
+
+RUN dnf -y module install python39 && dnf -y install python39 python39-pip
+RUN mkdir /plugin
+ADD https://raw.githubusercontent.com/arcalot/arcaflow-plugins/main/LICENSE /plugin
+COPY requirements.txt /plugin
+COPY fio_plugin.py /plugin
+
+WORKDIR /plugin
+
+ENTRYPOINT ["python3.9", "fio_plugin.py" ]
+CMD []

--- a/fixtures/wrong_label_values/Dockerfile
+++ b/fixtures/wrong_label_values/Dockerfile
@@ -1,0 +1,25 @@
+FROM quay.io/centos/centos:stream8
+
+RUN dnf -y module install python39 && dnf -y install python39 python39-pip
+RUN dnf -y install fio-3.19-3.el8
+RUN mkdir /plugin
+ADD https://raw.githubusercontent.com/arcalot/arcaflow-plugins/main/LICENSE /plugin
+COPY requirements.txt /plugin
+RUN pip3 install --requirement /plugin/requirements.txt
+COPY fio_plugin.py /plugin
+COPY fio_schema.py /plugin
+COPY test_fio_plugin.py /plugin
+COPY fixtures /plugin/fixtures
+
+WORKDIR /plugin
+RUN python3.9 test_fio_plugin.py
+
+ENTRYPOINT ["python3.9", "fio_plugin.py" ]
+CMD []
+
+LABEL org.opencontainers.image.source="https://github.com/example/example-plugin"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.vendor="Example project"
+LABEL org.opencontainers.image.authors="Example contributors"
+LABEL org.opencontainers.image.title="Example Plugin"
+LABEL io.github.arcalot.arcaflow.plugin.version="1"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.arcalot.io/arcaflow-container-toolkit
 
-go 1.24.3
+go 1.25.0
 
 require (
 	github.com/creasty/defaults v1.8.0
@@ -59,5 +59,4 @@ require (
 	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-
 )

--- a/internal/act/act.go
+++ b/internal/act/act.go
@@ -25,7 +25,7 @@ func ACT(build_img bool, push_img bool, cec ce_service.ContainerEngineService, c
 		return false, err
 	}
 	meets_reqs[0] = basic_reqs
-	container_reqs, err := requirements.ContainerfileRequirements(abspath, logger)
+	container_reqs, err := requirements.ContainerfileRequirements(abspath, conf.Label_Validation, logger)
 	if err != nil {
 		return false, err
 	}

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -135,7 +135,7 @@ func (ce CEClient) Push(destination string, username string, password string, re
 		Password:      password,
 		ServerAddress: registry_address,
 	}
-	authConfigBytes, _ := json.Marshal(authConfig)
+	authConfigBytes, _ := json.Marshal(authConfig) //nolint:gosec // G117: Password field is intentionally marshaled for Docker registry auth
 	authConfigEncoded := base64.URLEncoding.EncodeToString(authConfigBytes)
 	opts := image.PushOptions{RegistryAuth: authConfigEncoded}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*120)

--- a/internal/dto/act.go
+++ b/internal/dto/act.go
@@ -17,6 +17,7 @@ type ACT struct {
 	Build_Timeout    uint32 `default:"600"`
 	Archetype        string
 	Req_check_only   bool
+	Label_Validation string `default:"strict"`
 	Registries       []Registry
 }
 
@@ -38,6 +39,7 @@ func Unmarshal(push bool, logger log.Logger) (ACT, error) {
 		Build_Timeout:    viper.GetUint32("build_timeout"),
 		Archetype:        viper.GetString("archetype"),
 		Req_check_only:   viper.GetBool("req_check_only"),
+		Label_Validation: viper.GetString("label_validation"),
 		Registries:       registries}
 	if err := defaults.Set(&conf); err != nil {
 		return ACT{}, fmt.Errorf("error setting defaults (%w)", err)

--- a/internal/requirements/common.go
+++ b/internal/requirements/common.go
@@ -33,7 +33,7 @@ func LanguageRequirements(abspath string, filenames []string, name string, versi
 	case "python":
 		return PythonRequirements(abspath, filenames, name, version, logger, pythonCodeStyleChecker)
 	default:
-		return false, fmt.Errorf("Programming Language %s not supported\n", lang)
+		return false, fmt.Errorf("programming language %s not supported", lang)
 	}
 }
 

--- a/internal/requirements/containerfile.go
+++ b/internal/requirements/containerfile.go
@@ -8,7 +8,13 @@ import (
 	"go.arcalot.io/log/v2"
 )
 
-func ContainerfileRequirements(abspath string, logger log.Logger) (bool, error) {
+type labelCheck struct {
+	strictPattern string
+	existsPattern string
+	labelName     string
+}
+
+func ContainerfileRequirements(abspath string, labelValidation string, logger log.Logger) (bool, error) {
 	meets_reqs := true
 	project_files, err := os.Open(filepath.Clean(abspath))
 	if err != nil {
@@ -36,25 +42,68 @@ func ContainerfileRequirements(abspath string, logger log.Logger) (bool, error) 
 		}
 		dockerfile := string(file)
 
-		// create map of regexp patterns to search for in Dockerfile as well as log information if not found
-		m := map[string]string{
+		nonLabelChecks := map[string]string{
 			"FROM quay\\.io/(centos/centos:stream8|arcalot/arcaflow-plugin-baseimage-python-.*base)": "Dockerfile doesn't use a supported base image\n",
 			"(ADD|COPY) .*/?LICENSE /.*": "Dockerfile does not contain copy of arcaflow plugin license\n",
 			"CMD \\[\\]":                 "Dockerfile does not contain an empty command (i.e. CMD [])",
-			"LABEL org.opencontainers.image.source=\".*\"":                                     "Dockerfile is missing LABEL org.opencontainers.image.source",
-			"LABEL org.opencontainers.image.licenses=\"Apache-2\\.0.*\"":                       "Dockerfile is missing LABEL org.opencontainers.image.licenses",
-			"LABEL org.opencontainers.image.vendor=\"Arcalot project\"":                        "Dockerfile is missing LABEL org.opencontainers.image.vendor",
-			"LABEL org.opencontainers.image.authors=\"Arcalot contributors\"":                  "Dockerfile is missing LABEL org.opencontainers.image.authors",
-			"LABEL org.opencontainers.image.title=\".*\"":                                      "Dockerfile is missing LABEL org.opencontainers.image.title",
-			"LABEL io.github.arcalot.arcaflow.plugin.version=\"(\\d*)(\\.?\\d*?)(\\.?\\d*?)\"": "Dockerfile is missing LABEL io.github.arcalot.arcaflow.plugin.version that uses form X, X.Y, X.Y.Z",
 		}
 
-		for regexp_, loggerResp := range m {
+		for regexp_, loggerResp := range nonLabelChecks {
 			if has_, err := DockerfileHasLine(dockerfile, regexp_); err != nil {
 				return false, err
 			} else if !has_ {
 				logger.Infof(loggerResp)
 				meets_reqs = has_
+			}
+		}
+
+		labelChecks := []labelCheck{
+			{
+				strictPattern: `LABEL org.opencontainers.image.source=".*"`,
+				existsPattern: `LABEL org.opencontainers.image.source=`,
+				labelName:     "org.opencontainers.image.source",
+			},
+			{
+				strictPattern: `LABEL org.opencontainers.image.licenses="Apache-2\.0.*"`,
+				existsPattern: `LABEL org.opencontainers.image.licenses=`,
+				labelName:     "org.opencontainers.image.licenses",
+			},
+			{
+				strictPattern: `LABEL org.opencontainers.image.vendor="Arcalot project"`,
+				existsPattern: `LABEL org.opencontainers.image.vendor=`,
+				labelName:     "org.opencontainers.image.vendor",
+			},
+			{
+				strictPattern: `LABEL org.opencontainers.image.authors="Arcalot contributors"`,
+				existsPattern: `LABEL org.opencontainers.image.authors=`,
+				labelName:     "org.opencontainers.image.authors",
+			},
+			{
+				strictPattern: `LABEL org.opencontainers.image.title=".*"`,
+				existsPattern: `LABEL org.opencontainers.image.title=`,
+				labelName:     "org.opencontainers.image.title",
+			},
+			{
+				strictPattern: `LABEL io.github.arcalot.arcaflow.plugin.version="(\d*)(\.?\d*?)(\.?\d*?)"`,
+				existsPattern: `LABEL io.github.arcalot.arcaflow.plugin.version=`,
+				labelName:     "io.github.arcalot.arcaflow.plugin.version",
+			},
+		}
+
+		for _, lc := range labelChecks {
+			if labelValidation == "lenient" {
+				if has_, err := DockerfileHasLine(dockerfile, lc.existsPattern); err != nil {
+					return false, err
+				} else if !has_ {
+					logger.Warningf("Dockerfile is missing LABEL %s", lc.labelName)
+				}
+			} else {
+				if has_, err := DockerfileHasLine(dockerfile, lc.strictPattern); err != nil {
+					return false, err
+				} else if !has_ {
+					logger.Infof("Dockerfile is missing LABEL %s", lc.labelName)
+					meets_reqs = has_
+				}
 			}
 		}
 	}

--- a/internal/requirements/containerfile.go
+++ b/internal/requirements/containerfile.go
@@ -14,6 +14,39 @@ type labelCheck struct {
 	labelName     string
 }
 
+var labelChecks = []labelCheck{
+	{
+		strictPattern: `LABEL org.opencontainers.image.source=".*"`,
+		existsPattern: `LABEL org.opencontainers.image.source=`,
+		labelName:     "org.opencontainers.image.source",
+	},
+	{
+		strictPattern: `LABEL org.opencontainers.image.licenses="Apache-2\.0.*"`,
+		existsPattern: `LABEL org.opencontainers.image.licenses=`,
+		labelName:     "org.opencontainers.image.licenses",
+	},
+	{
+		strictPattern: `LABEL org.opencontainers.image.vendor="Arcalot project"`,
+		existsPattern: `LABEL org.opencontainers.image.vendor=`,
+		labelName:     "org.opencontainers.image.vendor",
+	},
+	{
+		strictPattern: `LABEL org.opencontainers.image.authors="Arcalot contributors"`,
+		existsPattern: `LABEL org.opencontainers.image.authors=`,
+		labelName:     "org.opencontainers.image.authors",
+	},
+	{
+		strictPattern: `LABEL org.opencontainers.image.title=".*"`,
+		existsPattern: `LABEL org.opencontainers.image.title=`,
+		labelName:     "org.opencontainers.image.title",
+	},
+	{
+		strictPattern: `LABEL io.github.arcalot.arcaflow.plugin.version="(\d*)(\.?\d*?)(\.?\d*?)"`,
+		existsPattern: `LABEL io.github.arcalot.arcaflow.plugin.version=`,
+		labelName:     "io.github.arcalot.arcaflow.plugin.version",
+	},
+}
+
 func ContainerfileRequirements(abspath string, labelValidation string, logger log.Logger) (bool, error) {
 	meets_reqs := true
 	project_files, err := os.Open(filepath.Clean(abspath))
@@ -34,80 +67,73 @@ func ContainerfileRequirements(abspath string, labelValidation string, logger lo
 	}
 	if !present {
 		logger.Infof("Missing Dockerfile")
+		return false, nil
+	}
+	file, err := os.ReadFile(filepath.Join(filepath.Clean(abspath), "Dockerfile"))
+	if err != nil {
+		return false, err
+	}
+	dockerfile := string(file)
+
+	nonLabelChecks := map[string]string{
+		"FROM quay\\.io/(centos/centos:stream8|arcalot/arcaflow-plugin-baseimage-python-.*base)": "Dockerfile doesn't use a supported base image\n",
+		"(ADD|COPY) .*/?LICENSE /.*": "Dockerfile does not contain copy of arcaflow plugin license\n",
+		"CMD \\[\\]":                 "Dockerfile does not contain an empty command (i.e. CMD [])",
+	}
+
+	for regexp_, loggerResp := range nonLabelChecks {
+		if has_, err := DockerfileHasLine(dockerfile, regexp_); err != nil {
+			return false, err
+		} else if !has_ {
+			logger.Infof(loggerResp)
+			meets_reqs = has_
+		}
+	}
+
+	labelsOK, err := checkLabels(dockerfile, labelValidation, logger)
+	if err != nil {
+		return false, err
+	}
+	if !labelsOK {
 		meets_reqs = false
-	} else {
-		file, err := os.ReadFile(filepath.Join(filepath.Clean(abspath), "Dockerfile"))
+	}
+
+	return meets_reqs, nil
+}
+
+func checkLabels(dockerfile string, labelValidation string, logger log.Logger) (bool, error) {
+	if labelValidation == "lenient" {
+		return checkLabelsLenient(dockerfile, logger)
+	}
+	return checkLabelsStrict(dockerfile, logger)
+}
+
+func checkLabelsLenient(dockerfile string, logger log.Logger) (bool, error) {
+	for _, lc := range labelChecks {
+		has, err := DockerfileHasLine(dockerfile, lc.existsPattern)
 		if err != nil {
 			return false, err
 		}
-		dockerfile := string(file)
-
-		nonLabelChecks := map[string]string{
-			"FROM quay\\.io/(centos/centos:stream8|arcalot/arcaflow-plugin-baseimage-python-.*base)": "Dockerfile doesn't use a supported base image\n",
-			"(ADD|COPY) .*/?LICENSE /.*": "Dockerfile does not contain copy of arcaflow plugin license\n",
-			"CMD \\[\\]":                 "Dockerfile does not contain an empty command (i.e. CMD [])",
-		}
-
-		for regexp_, loggerResp := range nonLabelChecks {
-			if has_, err := DockerfileHasLine(dockerfile, regexp_); err != nil {
-				return false, err
-			} else if !has_ {
-				logger.Infof(loggerResp)
-				meets_reqs = has_
-			}
-		}
-
-		labelChecks := []labelCheck{
-			{
-				strictPattern: `LABEL org.opencontainers.image.source=".*"`,
-				existsPattern: `LABEL org.opencontainers.image.source=`,
-				labelName:     "org.opencontainers.image.source",
-			},
-			{
-				strictPattern: `LABEL org.opencontainers.image.licenses="Apache-2\.0.*"`,
-				existsPattern: `LABEL org.opencontainers.image.licenses=`,
-				labelName:     "org.opencontainers.image.licenses",
-			},
-			{
-				strictPattern: `LABEL org.opencontainers.image.vendor="Arcalot project"`,
-				existsPattern: `LABEL org.opencontainers.image.vendor=`,
-				labelName:     "org.opencontainers.image.vendor",
-			},
-			{
-				strictPattern: `LABEL org.opencontainers.image.authors="Arcalot contributors"`,
-				existsPattern: `LABEL org.opencontainers.image.authors=`,
-				labelName:     "org.opencontainers.image.authors",
-			},
-			{
-				strictPattern: `LABEL org.opencontainers.image.title=".*"`,
-				existsPattern: `LABEL org.opencontainers.image.title=`,
-				labelName:     "org.opencontainers.image.title",
-			},
-			{
-				strictPattern: `LABEL io.github.arcalot.arcaflow.plugin.version="(\d*)(\.?\d*?)(\.?\d*?)"`,
-				existsPattern: `LABEL io.github.arcalot.arcaflow.plugin.version=`,
-				labelName:     "io.github.arcalot.arcaflow.plugin.version",
-			},
-		}
-
-		for _, lc := range labelChecks {
-			if labelValidation == "lenient" {
-				if has_, err := DockerfileHasLine(dockerfile, lc.existsPattern); err != nil {
-					return false, err
-				} else if !has_ {
-					logger.Warningf("Dockerfile is missing LABEL %s", lc.labelName)
-				}
-			} else {
-				if has_, err := DockerfileHasLine(dockerfile, lc.strictPattern); err != nil {
-					return false, err
-				} else if !has_ {
-					logger.Infof("Dockerfile is missing LABEL %s", lc.labelName)
-					meets_reqs = has_
-				}
-			}
+		if !has {
+			logger.Warningf("Dockerfile is missing LABEL %s", lc.labelName)
 		}
 	}
-	return meets_reqs, nil
+	return true, nil
+}
+
+func checkLabelsStrict(dockerfile string, logger log.Logger) (bool, error) {
+	passed := true
+	for _, lc := range labelChecks {
+		has, err := DockerfileHasLine(dockerfile, lc.strictPattern)
+		if err != nil {
+			return false, err
+		}
+		if !has {
+			logger.Infof("Dockerfile is missing LABEL %s", lc.labelName)
+			passed = false
+		}
+	}
+	return passed, nil
 }
 
 func DockerfileHasLine(dockerfile string, line string) (bool, error) {

--- a/internal/requirements/containerfile_test.go
+++ b/internal/requirements/containerfile_test.go
@@ -11,16 +11,49 @@ import (
 
 func TestContainerRequirements(t *testing.T) {
 	testCases := map[string]struct {
-		path           string
-		expectedResult bool
+		path            string
+		labelValidation string
+		expectedResult  bool
 	}{
-		"good_dockerfile": {
+		"good_dockerfile_strict": {
 			"../../fixtures/perfect",
+			"strict",
 			true,
 		},
-		"bad_dockerfile": {
+		"bad_dockerfile_strict": {
 			"../../fixtures/no_good",
+			"strict",
 			false,
+		},
+		"good_dockerfile_lenient": {
+			"../../fixtures/perfect",
+			"lenient",
+			true,
+		},
+		"bad_dockerfile_lenient": {
+			"../../fixtures/no_good",
+			"lenient",
+			false,
+		},
+		"no_labels_lenient": {
+			"../../fixtures/no_labels",
+			"lenient",
+			true,
+		},
+		"no_labels_strict": {
+			"../../fixtures/no_labels",
+			"strict",
+			false,
+		},
+		"wrong_label_values_strict": {
+			"../../fixtures/wrong_label_values",
+			"strict",
+			false,
+		},
+		"wrong_label_values_lenient": {
+			"../../fixtures/wrong_label_values",
+			"lenient",
+			true,
 		},
 	}
 
@@ -29,7 +62,7 @@ func TestContainerRequirements(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			logger := log.NewLogger(log.LevelInfo, log.NewNOOPLogger())
-			act, err := requirements.ContainerfileRequirements(tc.path, logger)
+			act, err := requirements.ContainerfileRequirements(tc.path, tc.labelValidation, logger)
 			if err != nil {
 				log2.Fatal(err)
 			}


### PR DESCRIPTION
## Summary
- Adds a `label_validation` config option with two modes: `strict` (default, current behavior) and `lenient`
- In lenient mode, only label key existence is checked and missing labels produce warnings instead of build failures, enabling ACT usage on non-Arcalot projects
- Migrates `.golangci.yaml` to golangci-lint v2 format (version field, gofmt as formatter, nested linter settings)
- Updates Go toolchain from 1.24.3 to 1.25.0
- Fixes pre-existing lint issues (staticcheck error string, gosec nolint annotation)

## Test plan
- [x] Existing tests updated and passing (`good_dockerfile_strict`, `bad_dockerfile_strict`)
- [x] New test cases: `good_dockerfile_lenient`, `bad_dockerfile_lenient`, `no_labels_lenient`, `no_labels_strict`, `wrong_label_values_strict`, `wrong_label_values_lenient`
- [x] Full test suite passes (`go test ./...`)
- [x] golangci-lint v2.11.4 passes with zero issues
- [ ] Manual validation: set `label_validation: lenient` in `.act.yaml` and run against a non-Arcalot Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)