### PR TITLE
Update arcaflow-container-toolkit-action to v1.5.0

### DIFF
--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: arcaflow-container-toolkit-action
-        uses: arcalot/arcaflow-container-toolkit-action@v1.4.0
+        uses: arcalot/arcaflow-container-toolkit-action@v1.5.0
         with:
           image_name: ${{ inputs.image_name }}
           image_tag: ${{ inputs.image_tag }}


### PR DESCRIPTION
## Summary
- Updates the reusable workflow to use `arcaflow-container-toolkit-action@v1.5.0` (from v1.4.0)
- Completes the circular dependency update: ACT released → action released → main updated to point to new action

## Test plan
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)