### PR TITLE
Fix invalid container image tags from branch names with slashes

### DIFF
--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -63,6 +63,7 @@ jobs:
               # Set image tags for any other builds (such as tags)
               bname=${GITHUB_REF##*/}
             fi
+            bname="${bname//\//-}"
             commit_hash=${{ github.sha }}
             IMAGE_TAGS="${{ env.QUAY_TAG_ROOT }}:${bname}_${commit_hash:0:7}"
             # Builds other than main and releases get automatic expiration


### PR DESCRIPTION
## Summary
- Sanitizes branch names by replacing `/` with `-` before constructing image tags
- Fixes buildah errors like `invalid reference format` when triggered from branches like `renovate/all` or `dependabot/go_modules/...`

The fix is a single bash substitution (`${bname//\//-}`) applied after the branch name is resolved and before it's used in the tag.

## Test plan
- [ ] CI passes
- [ ] Trigger a build from a branch with `/` in the name (e.g. `renovate/all`) and verify the image tag is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)